### PR TITLE
11 add a get route for the available configuration

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -16,6 +16,7 @@ PROMETHEUS_URL = os.getenv("PROMETHEUS_URL", "http://prometheus:9090")
 FIVEG_CORE_DOCKER_COMPOSE_PATH = os.getenv("FIVEG_CORE_DOCKER_COMPOSE_PATH", "/home/user/oai-cn5g/docker-compose.yaml")
 GNB_CONFIG_PATH = os.getenv("GNB_CONFIG_PATH","/home/user/openairinterface5g/targets/PROJECTS/GENERIC-NR-5GC/CONF/oaibox.yaml")
 GNB_EXECUTABLE = os.getenv("GNB_EXECUTABLE","/home/user/openairinterface5g/cmake_targets/ran_build/build/nr-softmodem")
+CONFIG_DIR = Path(os.getenv("CONFIG_DIR", "/home/user/openairinterface5g/targets/PROJECTS/GENERIC-NR-5GC/CONF"))
 
 gnb = GNodeBManager(config_path=GNB_CONFIG_PATH, executable_path=GNB_EXECUTABLE)
 
@@ -312,3 +313,26 @@ async def websocket_pcap(websocket: WebSocket):
 
     except WebSocketDisconnect:
         print("Client disconnected from /ws/gnb")
+
+@app.get("/gnb/config")
+def show_gnb_config():
+    """
+    Return a list of all .yaml or .conf files that contain 'gnb' in their name
+    from the predefined configuration directory.
+
+    Returns:
+        dict: A dictionary with a list of matching file names.
+    """
+    try:
+        if not CONFIG_DIR.exists():
+            raise HTTPException(status_code=404, detail="Configuration directory not found.")
+
+        files = [
+            f.name for f in CONFIG_DIR.iterdir()
+            if f.is_file() and "gnb" in f.name.lower() and f.suffix in [".yaml", ".conf"]
+        ]
+
+        return {"files": files}
+
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to list config files: {str(e)}")

--- a/backend/api.py
+++ b/backend/api.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from fastapi import FastAPI, HTTPException, WebSocket
 from starlette.websockets import WebSocketDisconnect
 from backend.wireshark.packet_manager import capture_packets

--- a/backend/api.py
+++ b/backend/api.py
@@ -326,7 +326,7 @@ def show_gnb_config():
     """
     try:
         if not CONFIG_DIR.exists():
-            raise HTTPException(status_code=404, detail="Configuration directory not found.")
+            raise HTTPException(status_code=500, detail="Invalid CONFIG_DIR: directory does not exist.")
 
         files = [
             f.name for f in CONFIG_DIR.iterdir()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
       - FIVEG_CORE_DOCK ER_COMPOSE_PATH=/home/user/oai-cn5g/docker-compose.yaml # [CoreNetwork] Path to CN5G docker-compose to manage CN5G
       - GNB_CONFIG_PATH=/home/user/openairinterface5g/targets/PROJECTS/GENERIC-NR-5GC/CONF/oaibox.yaml # [gNodeB] Path to gNB configuration file
       - GNB_EXECUTABLE=/home/user/openairinterface5g/cmake_targets/ran_build/build/nr-softmodem # [gNodeB] Path to gNB executable
+      - CONFIG_DIR = /home/user/openairinterface5g/targets/PROJECTS/GENERIC-NR-5GC/CONF
 
 
   prometheus:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,6 @@ services:
       - prometheus
 
 
-
   fastapiapp:
     privileged: true
     build:
@@ -47,7 +46,6 @@ services:
       - GNB_CONFIG_PATH=/home/user/openairinterface5g/targets/PROJECTS/GENERIC-NR-5GC/CONF/oaibox.yaml # [gNodeB] Path to gNB configuration file
       - GNB_EXECUTABLE=/home/user/openairinterface5g/cmake_targets/ran_build/build/nr-softmodem # [gNodeB] Path to gNB executable
       - CONFIG_DIR = /home/user/openairinterface5g/targets/PROJECTS/GENERIC-NR-5GC/CONF
-
 
   prometheus:
     image: prom/prometheus

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       - FIVEG_CORE_DOCK ER_COMPOSE_PATH=/home/user/oai-cn5g/docker-compose.yaml # [CoreNetwork] Path to CN5G docker-compose to manage CN5G
       - GNB_CONFIG_PATH=/home/user/openairinterface5g/targets/PROJECTS/GENERIC-NR-5GC/CONF/oaibox.yaml # [gNodeB] Path to gNB configuration file
       - GNB_EXECUTABLE=/home/user/openairinterface5g/cmake_targets/ran_build/build/nr-softmodem # [gNodeB] Path to gNB executable
-      - CONFIG_DIR = /home/user/openairinterface5g/targets/PROJECTS/GENERIC-NR-5GC/CONF
+      - CONFIG_DIR = /home/user/openairinterface5g/targets/PROJECTS/GENERIC-NR-5GC/CONF # [gNodeB] Path to the directory containing all configuration files for the gNodeB
 
   prometheus:
     image: prom/prometheus


### PR DESCRIPTION
I’ve added a GET method to the API at the route /gnb/config, which accesses the configuration folder from OAIBOX for the gNB and returns all the configuration files.